### PR TITLE
fix(ESM): Drop polyfill in ESM build

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -72,7 +72,6 @@ export default [
         browser: true,
       }),
       commonjs(),
-      inject(polyfills),
       babel({
         babelrc: false,
         include,


### PR DESCRIPTION
Drop polyfill in browsers that support ES modules